### PR TITLE
Chore: Bump graphql dependency -> 2.0.15

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     graphql-groups (0.2.1)
-      graphql (~> 1, > 1.9)
+      graphql (~> 2.0.15, > 1.9)
 
 GEM
   remote: https://rubygems.org/
@@ -28,14 +28,14 @@ GEM
       activerecord
       database_cleaner (~> 1.8.0)
     diff-lcs (1.4.4)
-    docile (1.3.2)
+    docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     gqli (1.0.0)
       hashie (~> 3.0)
       http (> 0.8, < 3.0)
       multi_json (~> 1)
-    graphql (1.11.1)
+    graphql (2.0.15)
     groupdate (5.2.1)
       activesupport (>= 5)
     gruff (0.10.0)
@@ -92,10 +92,12 @@ GEM
     rubocop-rspec (1.42.0)
       rubocop (>= 0.87.0)
     ruby-progressbar (1.10.1)
-    simplecov (0.18.5)
+    simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (1.4.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -121,8 +123,8 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (~> 0.88)
   rubocop-rspec (~> 1.42)
-  simplecov (~> 0.18.5)
+  simplecov (~> 0.21.2)
   sqlite3 (~> 1.4.2)
 
 BUNDLED WITH
-   2.2.26
+   2.3.16

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-groups (0.2.1)
+    graphql-groups (0.2.2)
       graphql (~> 2.0.15, > 1.9)
 
 GEM

--- a/graphql-groups.gemspec
+++ b/graphql-groups.gemspec
@@ -44,8 +44,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.88'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.42'
-  spec.add_development_dependency 'simplecov', '~> 0.18.5'
+  spec.add_development_dependency 'simplecov', '~> 0.21.2'
   spec.add_development_dependency 'sqlite3', '~> 1.4.2'
 
-  spec.add_dependency 'graphql', '~> 1', '> 1.9'
+  spec.add_dependency 'graphql', '~> 2.0.15', '> 1.9'
 end

--- a/lib/graphql/groups/version.rb
+++ b/lib/graphql/groups/version.rb
@@ -2,6 +2,6 @@
 
 module Graphql
   module Groups
-    VERSION = '0.2.1'
+    VERSION = '0.2.2'
   end
 end


### PR DESCRIPTION
Hi hans👋, I tried to find the guidelines for opening the PR and didn't find one :) Let me know where to get one and also i'm happy 🥳  to be the contributor of your project

**Problem Statement**

We wanted use graphql features of version above 2.x and graphql-groups is resolved and supports until the version 1.9. So, updated graphql dependency to support 2.0.15 version(which is the latest version).

The one problem is there might be breaking changes for the users who are using the older versions of graphql as i was not able to resolve the dependency to support older versions. Let me know how to resolve if there is an option for backward compatibility.

Also updated simplecov as it required ruby 2.4.0 and MAC M1 is not able to install 2.4.0 as it failing while compiling. This might be helpful for the users who might be facing the issue now or later :)